### PR TITLE
show_manager.start() was never called

### DIFF
--- a/docs/tutorials/02_advanced_ui/viz_ui.py
+++ b/docs/tutorials/02_advanced_ui/viz_ui.py
@@ -274,10 +274,7 @@ show_manager.scene.set_camera(position=(0, 0, 200))
 show_manager.scene.reset_clipping_range()
 show_manager.scene.azimuth(30)
 
-# To interact with the UI, set interactive = True
-interactive = False
 
-if interactive:
-    show_manager.start()
+show_manager.start()
 
 window.record(show_manager.scene, size=current_size, out_path="viz_ui.png")


### PR DESCRIPTION
Render Window did not appear when I tried to run the file.
No need for an interactive bool variable to call show_manager.start().
